### PR TITLE
Set notification priority max

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,6 @@ apply plugin: 'io.fabric'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "com.glodanif.bluetoothchat"

--- a/app/src/main/kotlin/com/glodanif/bluetoothchat/ui/view/NotificationViewImpl.kt
+++ b/app/src/main/kotlin/com/glodanif/bluetoothchat/ui/view/NotificationViewImpl.kt
@@ -14,6 +14,7 @@ import com.glodanif.bluetoothchat.data.service.BluetoothConnectionService
 import com.glodanif.bluetoothchat.utils.toReadableFileSize
 import com.glodanif.bluetoothchat.utils.getNotificationManager
 import android.app.PendingIntent
+import android.support.v4.content.ContextCompat
 
 
 class NotificationViewImpl(private val context: Context) : NotificationView {
@@ -47,11 +48,11 @@ class NotificationViewImpl(private val context: Context) : NotificationView {
                 .setSmallIcon(R.drawable.ic_notification)
                 .setContentIntent(pendingIntent)
                 .setOngoing(true)
-                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setPriority(NotificationCompat.PRIORITY_MAX)
                 .addAction(0, context.getString(R.string.notification__stop), stopPendingIntent)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            builder.color = resources.getColor(R.color.colorPrimary)
+            builder.color = ContextCompat.getColor(context, R.color.colorPrimary)
         }
 
         return builder.build()
@@ -94,7 +95,7 @@ class NotificationViewImpl(private val context: Context) : NotificationView {
                 .setPriority(NotificationCompat.PRIORITY_MAX)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            builder.color = resources.getColor(R.color.colorPrimary)
+            builder.color = ContextCompat.getColor(context, R.color.colorPrimary)
         }
 
         val notification = builder.build()
@@ -132,7 +133,7 @@ class NotificationViewImpl(private val context: Context) : NotificationView {
                 .setPriority(NotificationCompat.PRIORITY_MAX)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            builder.color = resources.getColor(R.color.colorPrimary)
+            builder.color = ContextCompat.getColor(context, R.color.colorPrimary)
         }
 
         val notification = builder.build()

--- a/app/src/main/kotlin/com/glodanif/bluetoothchat/ui/view/NotificationViewImpl.kt
+++ b/app/src/main/kotlin/com/glodanif/bluetoothchat/ui/view/NotificationViewImpl.kt
@@ -48,7 +48,7 @@ class NotificationViewImpl(private val context: Context) : NotificationView {
                 .setSmallIcon(R.drawable.ic_notification)
                 .setContentIntent(pendingIntent)
                 .setOngoing(true)
-                .setPriority(NotificationCompat.PRIORITY_MAX)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .addAction(0, context.getString(R.string.notification__stop), stopPendingIntent)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 
-    ext.KOTLIN_VERSION = '1.2.41'
+    ext.KOTLIN_VERSION = '1.2.51'
 
     repositories {
         google()
@@ -13,7 +13,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath 'io.fabric.tools:gradle:1.25.1'
+        classpath 'io.fabric.tools:gradle:1.25.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
     }
 }


### PR DESCRIPTION
Hi there, awesome app! I use it all the time to chat with my wife when we are on the airplane in separate seats 😄 

I noticed that on newer versions of Android, the STOP action in the persistent notification gets hidden, and you have to swipe downward to see the action. This can be frustrating, and took me quite some time to figure out how to make the persistent notification to go away. 

From what I read (and confirmed by making the modifications), changing the notification priority to MAX will assure that the STOP action always shows, as seen in the screenshot

![image](https://user-images.githubusercontent.com/1459320/42427183-c0f15778-82f2-11e8-9504-76aeeb21db43.png)
